### PR TITLE
rename Entity to Model. use Singleton pattern on Client.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.java]
+indent_style = tab
+indent_size = 2

--- a/HookAndroid/src/com/doubleleft/hook/Auth.java
+++ b/HookAndroid/src/com/doubleleft/hook/Auth.java
@@ -15,31 +15,32 @@ public class Auth {
 	public static String PROVIDER_EMAIL = "email";
 	public static String PROVIDER_FACEBOOK = "facebook";
 
-	protected static String AUTH_TOKEN_KEY = "dl-api-auth-token";
-	protected static String AUTH_DATA_KEY = "dl-api-auth-data";
-	
+	protected static String AUTH_TOKEN_KEY = "hook-auth-token";
+	protected static String AUTH_DATA_KEY = "hook-auth-data";
+
 	protected SharedPreferences localStorage;
 	protected JSONObject _currentUser;
-	
+
 	protected Client client;
 
-	public Auth(Client client, Context context) {
-		
+	public Auth(Client client) {
 		this.client = client;
-		
-		if (context != null) {
-			localStorage = context.getSharedPreferences("dl-api-localStorage-" + Client.appId, Context.MODE_PRIVATE);
+
+		if (context == null) {
+			// throw new Exception ...
 		}
 
+		localStorage = client.getContext().getSharedPreferences("hook-localStorage-" + client.getAppId(), Context.MODE_PRIVATE);
+
 		if (localStorage != null) {
-			String currentUser = localStorage.getString(Client.appId + "-" + AUTH_DATA_KEY, null);
+			String currentUser = localStorage.getString(client.getAppId() + "-" + AUTH_DATA_KEY, null);
 			if (currentUser != null) {
 				try {
 					JSONObject user = (JSONObject) new JSONTokener(currentUser).nextValue();
 					setCurrentUser(user);
 
 				} catch (JSONException e) {
-					Log.d("dl-api", "error on Auth module " + e.toString());
+					Log.d("hook", "error on Auth module " + e.toString());
 				}
 			}
 		}
@@ -96,7 +97,7 @@ public class Auth {
 	}
 
 	public String getAuthToken() {
-		return localStorage != null ? localStorage.getString(Client.appId + "-" + AUTH_TOKEN_KEY, null) : null;
+		return localStorage != null ? localStorage.getString(client.getAppId() + "-" + AUTH_TOKEN_KEY, null) : null;
 	}
 
 	protected void setCurrentUser(JSONObject data) {
@@ -105,10 +106,10 @@ public class Auth {
 		if (localStorage != null) {
 			SharedPreferences.Editor editor = localStorage.edit();
 			if (_currentUser == null) {
-				editor.remove(Client.appId + "-" + AUTH_TOKEN_KEY);
-				editor.remove(Client.appId + "-" + AUTH_DATA_KEY);
+				editor.remove(client.getAppId() + "-" + AUTH_TOKEN_KEY);
+				editor.remove(client.getAppId() + "-" + AUTH_DATA_KEY);
 			} else {
-				editor.putString(Client.appId + "-" + AUTH_DATA_KEY, _currentUser.toString());
+				editor.putString(client.getAppId() + "-" + AUTH_DATA_KEY, _currentUser.toString());
 			}
 			editor.commit();
 		}
@@ -123,7 +124,7 @@ public class Auth {
 		if (tokenObject != null) {
 			if (localStorage != null) {
 				SharedPreferences.Editor editor = localStorage.edit();
-				editor.putString(Client.appId + "-" + AUTH_TOKEN_KEY, tokenObject.optString("token"));
+				editor.putString(client.getAppId() + "-" + AUTH_TOKEN_KEY, tokenObject.optString("token"));
 				editor.commit();
 			}
 			setCurrentUser(data);

--- a/HookAndroid/src/com/doubleleft/hook/Model.java
+++ b/HookAndroid/src/com/doubleleft/hook/Model.java
@@ -9,21 +9,19 @@ import org.json.JSONObject;
 
 import android.util.Log;
 
-import com.doubleleft.hook.exceptions.ClientNotSetupException;
-
 /**
- * Base Entity Class. Your model Classes should extend this Class.
- * 
+ * Base Model Class. Your model Classes should extend this Class.
+ *
  * @author lucas.tulio
- * 
+ *
  */
-public abstract class Entity {
+public abstract class Model {
 
 	public void create(Responder responder) throws ClientNotSetupException {
 
 		// Populate fields using Reflection
 		HashMap<String, Object> hashMap = new HashMap<String, Object>();
-		for (Field field : this.getEntityFields()) {
+		for (Field field : this.getModelFields()) {
 			try {
 				hashMap.put(field.getName().toLowerCase(Locale.getDefault()), field.get(this));
 			} catch (Exception e) {
@@ -32,27 +30,26 @@ public abstract class Entity {
 		}
 
 		// D-D-D-D-DROP THE BASS
-		Client client = new Client();
-		String collectionName = this.getEntityName();
+		String collectionName = this.getModelName();
 		final JSONObject jsonObject = new JSONObject(hashMap);
-		client.collection(collectionName).create(jsonObject, responder);
+		Client.instance.collection(collectionName).create(jsonObject, responder);
 	}
 
 	/**
 	 * Reflection method to return the table fields
-	 * 
+	 *
 	 * @return
 	 */
-	private Field[] getEntityFields() {
+	private Field[] getModelFields() {
 
 		ArrayList<Field> fields = new ArrayList<Field>();
 		for (Field field : this.getClass().getFields()) {
 
-			if (field.getDeclaringClass() != Entity.class) {
+			if (field.getDeclaringClass() != Model.class) {
 				Log.d("Reflection", "Field: " + field.getName());
 				fields.add(field);
 			} else {
-				Log.d("Reflection", "(Ignoring Entity field: " + field.getName() + ")");
+				Log.d("Reflection", "(Ignoring Model field: " + field.getName() + ")");
 			}
 		}
 
@@ -61,14 +58,14 @@ public abstract class Entity {
 
 	/**
 	 * Reflection method to return the table name
-	 * 
+	 *
 	 * @return
 	 */
-	private String getEntityName() {
+	private String getModelName() {
 		String fullClassName = this.getClass().getName().toLowerCase(Locale.getDefault());
 		String[] parts = fullClassName.split("\\.");
-		String entityName = parts[parts.length - 1];
-		Log.d("Reflection", "Entity name: " + entityName);
-		return entityName;
+		String modelName = parts[parts.length - 1];
+		Log.d("Reflection", "Model name: " + modelName);
+		return modelName;
 	}
 }

--- a/HookSamples/src/com/doubleleft/hook/samples/MainActivity.java
+++ b/HookSamples/src/com/doubleleft/hook/samples/MainActivity.java
@@ -24,14 +24,7 @@ public class MainActivity extends Activity {
 		super.onCreate(savedInstanceState);
 		this.setContentView(R.layout.main_activity);
 
-		this.context = this;
-
-		// Setup hook
-		Client.appId = context.getString(R.string.hook_appId);
-		Client.appKey = context.getString(R.string.hook_appKey);
-		Client.url = context.getString(R.string.hook_endpointUrl);
-		
-		Client.context = this;
+		Client.configure(this);
 
 		Button requestButton = (Button) this.findViewById(R.id.request_button);
 		requestButton.setOnClickListener(new OnClickListener() {

--- a/HookSamples/src/com/doubleleft/hook/samples/model/Person.java
+++ b/HookSamples/src/com/doubleleft/hook/samples/model/Person.java
@@ -1,9 +1,8 @@
 package com.doubleleft.hook.samples.model;
 
-import com.doubleleft.hook.Entity;
+import com.doubleleft.hook.Model;
 
-public class Person extends Entity {
-
+public class Person extends Model {
 	public String name;
 	public int age;
 }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-Hook-android
+hook-android
 ===
 
-Hook android client
+Java/Android client for [hook](https://github.com/doubleleft/hook)
 
 #About
 
-This is a port of the [JavaScript client](http://github.com/doubleleft/hook-javascript). The library is a native Android Library, with no external dependencies, targetting Android API Level 10. It doesn't require the JavaScript client either, the library communicates with hook's REST interface. 
+This is a port of the [JavaScript client](http://github.com/doubleleft/hook-javascript). The library is a native Android Library, with no external dependencies, targetting Android API Level 10. It doesn't require the JavaScript client either, the library communicates with hook's REST interface.
 
 #How to Use
 


### PR DESCRIPTION
@lucasdnd modifiquei algumas coisas, não cheguei a compilar ainda, quando puder dá uma conferida se faz sentido:
- Tendo definido por padrão as strings `R.string.hook_appId`, etc, daria para inicializar uma instância global do client com `Client.configure(context)`
- Renomeado de `Entity` para `Model` (para ficar igual em todos os clients)
- Removido checagens prevendo a existência de `context`, pois à principio ele vai sempre existir (se não existir teria que jogar uma excessão mesmo)
- Removido getters e setters para instâncias padrão do client, como `Auth`, `KeyValues` e `System`.
